### PR TITLE
remove cp config/sample files from installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Follow these steps to get started in development.
 
 Clone the repository
 
-    $ git clone git@github.com:zacharywelch/lightning_talks.git
+    $ git clone git@github.com:callrail/lightning_talks.git
 
 Switch to the project's directory
 
@@ -24,20 +24,6 @@ Switch to the project's directory
 Then bundle
 
     $ bundle
-
-Copy database.yml.sample as database.yml
-
-    $ cp config/database.yml.sample config/database.yml
-
-Copy secrets.yml.sample as secrets.yml
-
-    $ cp config/secrets.yml.sample config/secrets.yml
-
-Copy aws.yml.sample as aws.yml
-
-    $ cp config/aws.yml.sample config/aws.yml
-
-Make sure all config files mentioned above are filled with the proper configuration data
 
 Run the migrations
 


### PR DESCRIPTION
Removed the config copy steps since we're using env variables. Ran through the steps from scratch and was able to get the app started and specs passing w/o problems. Is there anything else you think is missing or worth mentioning for newcomers?